### PR TITLE
Fix old twitter handle listed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Contact us
 ----------
 
 We'd love to hear from you if you are using this in your projects!  Please drop us a
-line: [@stat_hat](http://twitter.com/stat_hat) or [contact us here](http://www.stathat.com/docs/contact).
+line: [@stathat](http://twitter.com/stathat) or [contact us here](http://www.stathat.com/docs/contact).
 
 About
 -----


### PR DESCRIPTION
Minor change, but clicked on the link to the stathat twitter account and found out that this is an old one.
